### PR TITLE
Implement functions for following HTTP redirects

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -224,6 +224,12 @@ test ('autoBufferResponse', () => Promise.all ([
 
 const respond200 = mockResponse ({}) (Buffer.from ('hello'));
 
+test ('matchStatus', () => Promise.all ([
+  assertResolves (fl.map (fn.matchStatus (() => 'else') ({200: () => '200', 201: () => '201'})) (mockResponse ({code: 400}) (Buffer.from ('hello')))) ('else'),
+  assertResolves (fl.map (fn.matchStatus (() => 'else') ({200: () => '200', 201: () => '201'})) (mockResponse ({code: 200}) (Buffer.from ('hello')))) ('200'),
+  assertResolves (fl.map (fn.matchStatus (() => 'else') ({200: () => '200', 201: () => '201'})) (mockResponse ({code: 201}) (Buffer.from ('hello')))) ('201'),
+]));
+
 test ('acceptStatus', () => Promise.all ([
   assertResolves (fl.map (thenBuffer) (fl.map (fn.acceptStatus (200)) (respond200)))
                  (fl.resolve ('hello')),

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ import test from 'oletus';
 import {Readable} from 'stream';
 import {equivalence, equality as eq} from 'fluture/test/assertions.js';
 import {withTestServer} from './server.js';
+import {lookup} from 'dns';
 
 import * as fn from '../index.js';
 
@@ -150,6 +151,40 @@ test ('Response', () => {
   const response = fn.Response (request) (message);
   eq (fn.Response.request (response)) (request);
   eq (fn.Response.message (response)) (message);
+});
+
+test ('cleanRequestOptions', () => {
+  const req = o => fn.Request (o) ('https://example.com') (fn.emptyStream);
+  eq (fn.cleanRequestOptions (req ({}))) ({
+    agent: undefined,
+    createConnection: undefined,
+    defaultPort: undefined,
+    family: undefined,
+    headers: {},
+    insecureHTTPParser: false,
+    localAddress: undefined,
+    lookup: lookup,
+    maxHeaderSize: 16384,
+    method: 'GET',
+    setHost: true,
+    socketPath: undefined,
+    timeout: undefined,
+  });
+  eq (fn.cleanRequestOptions (req ({agent: {defaultPort: 42}}))) ({
+    agent: {defaultPort: 42},
+    createConnection: undefined,
+    defaultPort: 42,
+    family: undefined,
+    headers: {},
+    insecureHTTPParser: false,
+    localAddress: undefined,
+    lookup: lookup,
+    maxHeaderSize: 16384,
+    method: 'GET',
+    setHost: true,
+    socketPath: undefined,
+    timeout: undefined,
+  });
 });
 
 test ('bufferResponse', () => Promise.all ([

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,47 @@
+import * as fl from 'fluture';
+import http from 'http';
+import {bufferString} from '../index.js';
+
+export const echoHandler = req => res => body => fl.attempt (() => {
+  res.writeHead (200, {'Content-Type': 'text/plain', 'Date': 'now'});
+  res.end (Buffer.from (`${req.method}/${body}`));
+});
+
+export const routes = Object.assign (Object.create (null), {
+  'GET /echo': echoHandler,
+  'POST /echo': echoHandler,
+});
+
+export const routeRequest = req => res => body => {
+  const route = routes[`${req.method} ${req.url}`];
+  if (typeof route === 'function') {
+    return route (req) (res) (body);
+  } else {
+    return fl.attempt (() => {
+      res.writeHead (404, {'Content-Type': 'text/plain'});
+      res.end (Buffer.from ('Not Found'));
+    });
+  }
+};
+
+export const acquireTestServer = fl.Future ((rej, res) => {
+  const server = http.createServer ((req, res) => {
+    bufferString ('utf8') (req)
+    .pipe (fl.chain (routeRequest (req) (res)))
+    .pipe (fl.fork (e => {
+      res.writeHead (500, {'Content-Type': 'text/plain'});
+      res.end ('Bad request: ' + String (e));
+    }) (() => {}));
+  });
+  server.listen (() => {
+    const {port} = server.address ();
+    res ({url: `http://localhost:${port}`, server});
+  });
+  return () => {
+    server.close (() => {});
+  };
+});
+
+export const disposeTestServer = ({server}) => fl.node (server.close.bind (server));
+
+export const withTestServer = fl.hook (acquireTestServer) (disposeTestServer);

--- a/test/server.js
+++ b/test/server.js
@@ -7,9 +7,35 @@ export const echoHandler = req => res => body => fl.attempt (() => {
   res.end (Buffer.from (`${req.method}/${body}`));
 });
 
+export const redirectHandler = req => res => body => fl.attempt (() => {
+  res.writeHead (301, {'Location': '/echo'});
+  res.end ();
+});
+
+export const redirectPostHandler = req => res => body => fl.attempt (() => {
+  res.writeHead (305, {'Location': '/echo'});
+  res.end ();
+});
+
+export const selfRedirectHandler = req => res => body => fl.attempt (() => {
+  res.writeHead (301, {'Location': '/self-redirect'});
+  res.end ();
+});
+
+export const redirectLoopHandler = req => res => body => fl.attempt (() => {
+  res.writeHead (301, {'Location': req.url.replace (/[ab]$/, x => x === 'a' ? 'b' : 'a')});
+  res.end ();
+});
+
 export const routes = Object.assign (Object.create (null), {
   'GET /echo': echoHandler,
   'POST /echo': echoHandler,
+  'GET /redirect': redirectHandler,
+  'POST /redirect': redirectHandler,
+  'POST /redirect-post': redirectPostHandler,
+  'GET /self-redirect': selfRedirectHandler,
+  'GET /redirect-loop-a': redirectLoopHandler,
+  'GET /redirect-loop-b': redirectLoopHandler,
 });
 
 export const routeRequest = req => res => body => {


### PR DESCRIPTION
This feature will be implemented over ~two~ several commits. The initial commits support the last one. See the commit message bodies for extended explanations.